### PR TITLE
Numpy fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ if 'PGPLOT_PNG' in os.environ:
 else:
     raise Exception('Environment variable PGPLOT_PNG not defined')
 
-library_dirs = ['/usr/X11R6/lib', '/opt/local/lib']
+library_dirs = ['/usr/X11R6/lib', '/opt/local/lib', 'opt/homebrew/lib']
+library_dirs = [d for d in library_dirs if os.path.exists(d)]
 
 include_dirs.append(numpy.get_include())
 

--- a/trm/pgplot/_pgplot.pyx
+++ b/trm/pgplot/_pgplot.pyx
@@ -5,7 +5,7 @@ cimport cpgplot
 
 FTYPE = np.float32
 DTYPE = np.float64
-ITYPE = np.int
+ITYPE = np.int32
 ctypedef np.float32_t FTYPE_t
 ctypedef np.float64_t DTYPE_t
 ctypedef np.int_t ITYPE_t


### PR DESCRIPTION
`np.int` was deprecated in Numpy version 1.20 and is an error raising issue in v1.24